### PR TITLE
Add a multivariate log-likelihood splitting rule for competing risk settings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,15 +1,19 @@
 Package: rfSLAM
 Version: 0.0.2
-Date: 2020-01-20
+Date: 2020-10-09
 Title: Random Forests for Survival, Regression, and Classification
         (RF-SRC)
 Author: Shannon Wongvibulsin <swongvi1@jhmi.edu>, Matt Rosen <mattrosen@uchicago.edu>
 Maintainer: Matt Rosen <mattrosen@uchicago.edu>
+BugReports: https://github.com/mattrosen/rfSLAM/issues/new
 Depends: R (>= 3.5.1),
 Imports: parallel, pracma
 Suggests: glmnet, survival, pec, prodlim, mlbench, RCurl
 Description: Implementation of random forests for survival, longitudinal, and multivariate data; modified from randomForestSRC, by Ishwaran and Kogalur. We reproduce their package description here: "A unified treatment of Breiman's random forests for survival, regression and classification problems based on Ishwaran and Kogalur's random survival forests (RSF) package.  Now extended to include multivariate and unsupervised forests.  Also includes quantile regression forests for univariate and multivariate training/testing settings.  The package runs in both serial and parallel (OpenMP) modes."
 License: GPL (>= 3)
+URL: https://github.com/mattrosen/rfSLAM
 NeedsCompilation: yes
-Packaged: 2020-01-20 01:21:12 UTC; sivanov
+Packaged: 2018-05-18 02:12:12 UTC; kogalur
+Repository: CRAN
+Date/Publication: 2018-05-18 12:42:16 UTC
 RoxygenNote: 6.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rfSLAM
-Version: 0.0.1-6
+Version: 0.0.1-5
 Date: 2020-01-20
 Title: Random Forests for Survival, Regression, and Classification
         (RF-SRC)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rfSLAM
-Version: 0.0.1-5
+Version: 0.0.2
 Date: 2020-01-20
 Title: Random Forests for Survival, Regression, and Classification
         (RF-SRC)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,19 +1,15 @@
 Package: rfSLAM
-Version: 0.0.1
-Date: 2018-12-02
+Version: 0.0.1-2
+Date: 2020-01-20
 Title: Random Forests for Survival, Regression, and Classification
         (RF-SRC)
 Author: Shannon Wongvibulsin <swongvi1@jhmi.edu>, Matt Rosen <mattrosen@uchicago.edu>
 Maintainer: Matt Rosen <mattrosen@uchicago.edu>
-BugReports: https://github.com/mattrosen/rfSLAM/issues/new
 Depends: R (>= 3.5.1),
 Imports: parallel, pracma
 Suggests: glmnet, survival, pec, prodlim, mlbench, RCurl
 Description: Implementation of random forests for survival, longitudinal, and multivariate data; modified from randomForestSRC, by Ishwaran and Kogalur. We reproduce their package description here: "A unified treatment of Breiman's random forests for survival, regression and classification problems based on Ishwaran and Kogalur's random survival forests (RSF) package.  Now extended to include multivariate and unsupervised forests.  Also includes quantile regression forests for univariate and multivariate training/testing settings.  The package runs in both serial and parallel (OpenMP) modes."
 License: GPL (>= 3)
-URL: https://github.com/mattrosen/rfSLAM
 NeedsCompilation: yes
-Packaged: 2018-05-18 02:12:12 UTC; kogalur
-Repository: CRAN
-Date/Publication: 2018-05-18 12:42:16 UTC
+Packaged: 2020-01-20 01:21:12 UTC; sivanov
 RoxygenNote: 6.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rfSLAM
-Version: 0.0.1-2
+Version: 0.0.1-3
 Date: 2020-01-20
 Title: Random Forests for Survival, Regression, and Classification
         (RF-SRC)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rfSLAM
-Version: 0.0.1-4
+Version: 0.0.1-5
 Date: 2020-01-20
 Title: Random Forests for Survival, Regression, and Classification
         (RF-SRC)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rfSLAM
-Version: 0.0.1-5
+Version: 0.0.1-6
 Date: 2020-01-20
 Title: Random Forests for Survival, Regression, and Classification
         (RF-SRC)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rfSLAM
-Version: 0.0.1-3
+Version: 0.0.1-4
 Date: 2020-01-20
 Title: Random Forests for Survival, Regression, and Classification
         (RF-SRC)

--- a/R/rfsrc.R
+++ b/R/rfsrc.R
@@ -1379,9 +1379,6 @@ rfsrc <- function(formula,
     else if (strcmp(splitrule, "multinomial.split")) {
       splitrule <- "custom8"
     }
-    else if (strcmp(splitrule, "gini.split")) {
-      splitrule <- "custom9"
-    }
   }
 
   splitinfo <- get.grow.splitinfo(formulaDetail, splitrule, htry, nsplit, event.info$event.type)

--- a/R/rfsrc.R
+++ b/R/rfsrc.R
@@ -1379,6 +1379,9 @@ rfsrc <- function(formula,
     else if (strcmp(splitrule, "multinomial.split")) {
       splitrule <- "custom8"
     }
+    else if (strcmp(splitrule, "gini.split")) {
+      splitrule <- "custom9"
+    }
   }
 
   splitinfo <- get.grow.splitinfo(formulaDetail, splitrule, htry, nsplit, event.info$event.type)

--- a/R/rfsrc.R
+++ b/R/rfsrc.R
@@ -1376,6 +1376,9 @@ rfsrc <- function(formula,
     else if (strcmp(splitrule, "poisson.split6")) {
       splitrule <- "custom7"
     }
+    else if (strcmp(splitrule, "multinomial.split")) {
+      splitrule <- "custom8"
+    }
   }
 
   splitinfo <- get.grow.splitinfo(formulaDetail, splitrule, htry, nsplit, event.info$event.type)
@@ -1650,6 +1653,7 @@ rfsrc <- function(formula,
                                   as.integer(get.rf.cores()))}, error = function(e) {
                                     print(e)
                                     NULL})
+  
   ## check for error return condition in the native code
   if (is.null(nativeOutput)) {
     if (impute.only) {

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,2 +1,2 @@
-PKG_CFLAGS = -fopenmp
-PKG_LIBS   = -fopenmp
+PKG_CFLAGS = #-fopenmp
+PKG_LIBS   = #-fopenmp

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,2 +1,2 @@
-PKG_CFLAGS = #-fopenmp
-PKG_LIBS   = #-fopenmp
+PKG_CFLAGS = -fopenmp
+PKG_LIBS   = -fopenmp

--- a/src/splitCustom.c
+++ b/src/splitCustom.c
@@ -62,7 +62,7 @@ void registerCustomFunctions() {
     registerThis (&poissonSplit6, CLAS_FAM, 7);
     registerThis (&getCustomSplitStatisticMultivariateRegressionSeven, REGR_FAM, 7);
     
-    registerThis (&binomialSplit, CLAS_FAM, 8);
+    registerThis (&multinomialSplit, CLAS_FAM, 8);
     registerThis (&getCustomSplitStatisticMultivariateRegressionEight, REGR_FAM, 8);
   //  registerThis (&getCustomSplitStatisticSurvivalTwo, SURV_FAM, 2);
   //  registerThis (&getCustomSplitStatisticCompetingRiskTwo, CRSK_FAM, 2);
@@ -1715,12 +1715,12 @@ double getCustomSplitStatisticMultivariateRegressionSeven (unsigned int n,
 /******************************************************************************/
 
 /**
- * Poisson split 6: with stratification by interval time but not risk time,
- *                  no Bayes estimate.
+ * Multinomial split: random survival forest with P - 1 competing risks and equal
+ * length discrete time periods
  * ------------------------------------------------------------------------
  * for speed, we unroll computations for each of the daughter nodes.
  */
-double binomialSplit (unsigned int n,
+double multinomialSplit (unsigned int n,
                       double k_for_alpha,
                       char        *membership,
                       double      *time,
@@ -1738,7 +1738,196 @@ double binomialSplit (unsigned int n,
                       double     **feature,
                       unsigned int featureCount)
 {
-  return 0;
+  /* necessary vars */
+  int i, p, k, K = 0; // i is observation, k is strata (period), p is event, K is last period in parent leaf
+  double stat = 0.0, stat_L = 0.0, stat_R = 0.0;
+  
+  /**
+   * determine K; also, check that response conforms
+   * with expectations (2 classes, 1.0 and 2.0)
+   */
+  for (i = 1; i <= n; i++) {
+    if (feature[1][i] > K) 
+      K = feature[1][i]; // feature [1][i] contains period of observation i
+      /*if (response[i] > 2.0) {
+        fprintf(stderr, "response variable error: this custom split function for classification\n \
+                    does not yet support k-class classification for k > 2; your response\n        \
+                    took value %f.\n", response[i]);
+        exit(1);
+      }
+      if (response[i] < 0.0) {
+        fprintf(stderr, "response variable error: this custom split function for classification\n \
+                    expects responses with values in {0.0, 1.0, 2.0}. Yours assumed value %f.\n", 
+                    response[i]);
+        exit(1);
+      }*/
+  }
+  
+  
+  /* arrays for results; pre-allocate everything, 
+   for L and R, too, for speed */
+  
+  //PARENT
+  // hazard rate for event p at time k in parent s
+  double** h_kps = calloc((K + 1), sizeof(double*));
+  for (i = 0; i < K + 1; i++) {
+    h_kps[i] = calloc((maxLevel + 1), sizeof(double));
+  }
+  // occurence of event p at time k in parent s
+  int** e_kps = calloc((K + 1), sizeof(int*));
+  for (i = 0; i < K + 1; i++) {
+    e_kps[i] = calloc((maxLevel + 1), sizeof(int));
+  }
+  // risk set at time k in parent s
+  int *r_ks  = calloc((K + 1), sizeof(int));
+  
+  // LEFT child node
+  double** h_kps_L = calloc((K + 1), sizeof(double*));
+  for (i = 0; i < K + 1; i++) {
+    h_kps_L[i] = calloc((maxLevel + 1), sizeof(double));
+  }
+  int** e_kps_L = calloc((K + 1), sizeof(int*));
+  for (i = 0; i < K + 1; i++) {
+    e_kps_L[i] = calloc((maxLevel + 1), sizeof(int));
+  }
+  int *r_ks_L  = calloc((K + 1), sizeof(int));
+  
+  // RIGHT child node
+  double** h_kps_R = calloc((K + 1), sizeof(double*));
+  for (i = 0; i < K + 1; i++) {
+    h_kps_R[i] = calloc((maxLevel + 1), sizeof(double));
+  }
+  int** e_kps_R = calloc((K + 1), sizeof(int*));
+  for (i = 0; i < K + 1; i++) {
+    e_kps_R[i] = calloc((maxLevel + 1), sizeof(int));
+  }
+  int *r_ks_R  = calloc((K + 1), sizeof(int));
+  
+  /* compute e_kps, r_ks and h_kps! */
+  /* make the pass through, count necessary quantities */
+  int cur_y, cur_k;
+  
+  for (i = 1; i <= n; i++) {
+    
+    cur_y  = (int) response[i];
+    cur_k  = (int) feature[1][i];
+    // risk time 1 due to periods of length 1
+    
+    /****************/
+    /**   parent   **/
+    /****************/
+    /* increment e_kps, r_ks appropriately  */
+    /*
+     * number of persons experiecing event cur_y at k
+     */
+    e_kps[cur_k][cur_y]++;
+    /*
+     * risk set for period k is simply the number of 
+     * person period observations at k
+     */
+    r_ks[cur_k]++;
+    
+    /****************/
+    /** L DAUGHTER **/
+    /****************/
+    
+    if (membership[i] == LEFT) {
+      e_kps_L[cur_k][cur_y]++;
+      r_ks_L[cur_k]++;
+    }
+    
+    /****************/
+    /** R DAUGHTER **/
+    /****************/
+    else {
+      e_kps_R[cur_k][cur_y]++;
+      r_ks_R[cur_k]++;
+    }
+    
+  }
+  
+  /* divide to find h_kps, calc. split statistic for 
+   each case */
+  for (k = 1; k <= K; i++) {
+    // if no person period observations at k
+    if (r_ks[k] != 0) {
+      // then no hazard for all events
+      // (event 1 is censored)
+      // for(p = 2; p <= maxLevel; p ++) {
+      //   h_kps[k][p] = 0.0;  
+      // }
+      for(p = 1; p <= maxLevel; p ++) {
+        h_kps[k][p] = e_kps[cur_k][p] / r_ks[k];  
+      }
+    }
+    // LEFT
+    if (r_ks_L[k] != 0) {
+      for(p = 1; p <= maxLevel; p ++) {
+        h_kps_L[k][p] = e_kps_L[cur_k][p] / r_ks_L[k];
+      }
+    }
+    // RIGHT
+    if (r_ks_R[k] != 0) {
+      for(p = 1; p <= maxLevel; p ++) {
+        h_kps_R[k][p] = e_kps_R[cur_k][p] / r_ks_R[k];
+      }
+    }
+  }
+  
+  /* calculate the split statistic for each case; ignore
+   cases when the value of mu is 0 (else will result in 
+   NaNs) */
+  for (k = 1; k <= K; k++) {
+    
+    /*
+     * parent likelihood per period:
+     * number of event occurences * log (empirical MLE of likelhood of event occurence)
+     */
+    if (r_ks[k] != 0){
+      for(p = 1; p <= maxLevel; p ++){
+        if (h_kps[k][p] != 0){
+          stat += e_kps[k][p] * log(h_kps[k][p]);
+        }
+      }
+    }
+    // LEFT
+    if (r_ks_L[k] != 0){
+      for(p = 1; p <= maxLevel; p ++){
+        if (h_kps_L[k][p] != 0){
+          stat_L += e_kps_L[k][p] * log(h_kps_L[k][p]);
+        }
+      }
+    }
+    // RIGHT
+    if (r_ks_R[k] != 0){
+      for(p = 1; p <= maxLevel; p ++){
+        if (h_kps_R[k][p] != 0){
+          stat_R += e_kps_R[k][p] * log(h_kps_R[k][p]);
+        }
+      }
+    }
+    
+  }
+  
+  /* free memory
+   * h_kps e_kps r_ks
+   */
+  free(h_kps);
+  free(e_kps);
+  free(r_ks);
+  
+  free(h_kps_L);
+  free(e_kps_L);
+  free(r_ks_L);
+  
+  free(h_kps_R);
+  free(e_kps_R);
+  free(r_ks_R);
+  
+  printf("%f\n", stat_L + stat_R - stat);
+  
+  /* determine delta, return */
+  return (stat_L + stat_R - stat);
 }
 
 double getCustomSplitStatisticMultivariateRegressionEight (unsigned int n,

--- a/src/splitCustom.c
+++ b/src/splitCustom.c
@@ -67,6 +67,9 @@ void registerCustomFunctions() {
     
     registerThis (&giniSplit, CLAS_FAM, 9);
     registerThis (&getCustomSplitStatisticMultivariateRegressionNine, REGR_FAM, 9);
+    
+    registerThis (&multinomialWeightedSplit, CLAS_FAM, 10);
+    registerThis (&getCustomSplitStatisticMultivariateRegressionTen ,REGR_FAM, 10);
   //  registerThis (&getCustomSplitStatisticSurvivalTwo, SURV_FAM, 2);
   //  registerThis (&getCustomSplitStatisticCompetingRiskTwo, CRSK_FAM, 2);
 
@@ -1887,6 +1890,203 @@ double multinomialSplit (unsigned int n,
   /* determine delta, return */
   return (stat_L + stat_R - stat);
 }
+
+double getCustomSplitStatisticMultivariateRegressionTen (unsigned int n,
+                                                           double k_for_alpha,
+                                                           char        *membership,
+                                                           double      *time,
+                                                           double      *event,
+                                                           
+                                                           unsigned int eventTypeSize,
+                                                           unsigned int eventTimeSize,
+                                                           double      *eventTime,
+                                                           
+                                                           double      *response,
+                                                           double       mean,
+                                                           double       variance,
+                                                           unsigned int maxLevel,
+                                                           
+                                                           double     **feature,
+                                                           unsigned int featureCount)
+{
+  fprintf(stderr, "outcome must be a factor; custom regression rule not yet implemented.\n");
+  exit(1);
+  
+}
+
+/**
+ * Multinomial split: random survival forest with P - 1 competing risks and equal
+ * length discrete time periods
+ * ------------------------------------------------------------------------
+ * for speed, we unroll computations for each of the daughter nodes.
+ */
+double multinomialWeightedSplit (unsigned int n,
+                         double k_for_alpha,
+                         char        *membership,
+                         double      *time,
+                         double      *event,
+                         
+                         unsigned int eventTypeSize,
+                         unsigned int eventTimeSize,
+                         double      *eventTime,
+                         
+                         double      *response,
+                         double       mean,
+                         double       variance,
+                         unsigned int maxLevel,
+                         
+                         double     **feature,
+                         unsigned int featureCount)
+{
+  /* necessary vars */
+  // i is observation, k is strata (period), p is event, K is last period in parent leaf
+  int i, p, k, K = 0; 
+  double stat = 0.0, stat_L = 0.0, stat_R = 0.0;
+  const unsigned int eventCosts[3] = {1, 30, 500};
+  
+  /**
+   * determine K; also, check that response conforms
+   * with expectations (2 classes, 1.0 and 2.0)
+   */
+  for (i = 1; i <= n; i++) {
+    if (feature[1][i] > K){
+      // feature [1][i] contains period of observation i
+      K = feature[1][i];
+    } 
+  }
+  
+  /* arrays for results; pre-allocate everything, 
+   for L and R, too, for speed */
+  
+  // event set cardinalities at time tim k for revent p at parent s
+  unsigned int   **e_kps,  **e_kps_L, **e_kps_R;
+  // event set cardinalities at time tim k at parent s
+  unsigned int   *r_ks, *r_ks_L, *r_ks_R;
+  
+  /****************/
+  /**   parent   **/
+  /****************/
+  e_kps = calloc_uimatrix(K, maxLevel);
+  r_ks = calloc_uivector(K);
+  
+  /****************/
+  /** L DAUGHTER **/
+  /****************/
+  e_kps_L = calloc_uimatrix(K, maxLevel);
+  r_ks_L = calloc_uivector(K);
+  
+  /****************/
+  /** R DAUGHTER **/
+  /****************/
+  e_kps_R = calloc_uimatrix(K, maxLevel);
+  r_ks_R = calloc_uivector(K);
+  
+  /* compute e_kps, r_ks and h_kps! */
+  /* make the pass through, count necessary quantities */
+  int cur_y, cur_k;
+  
+  for (i = 1; i <= n; i++) {
+    
+    cur_y  = (int) response[i];
+    cur_k  = (int) feature[1][i];
+    // risk time 1 due to periods of length 1
+    
+    /****************/
+    /**   parent   **/
+    /****************/
+    /* increment e_kps, r_ks appropriately  */
+    /*
+     * number of persons experiecing event cur_y at k
+     */
+    e_kps[cur_k][cur_y]++;
+    /*
+     * risk set for period k is simply the number of 
+     * person period observations at k
+     */
+    r_ks[cur_k]++;
+    
+    /****************/
+    /** L DAUGHTER **/
+    /****************/
+    if (membership[i] == LEFT) {
+      e_kps_L[cur_k][cur_y]++;
+      r_ks_L[cur_k]++;
+    }
+    
+    /****************/
+    /** R DAUGHTER **/
+    /****************/
+    else {
+      e_kps_R[cur_k][cur_y]++;
+      r_ks_R[cur_k]++;
+    }
+    
+  }
+  
+  /* calculate the split statistic for each case; ignore
+   cases when the value of r_ks or h_kps is 0 (else will result in 
+   NaNs) */
+  for (k = 1; k <= K; k++) {
+    
+    /*
+     * parent negative log likelihood per period:
+     * number of event occurences * log (empirical MLE of likelhood of event occurence)
+     */
+    /****************/
+    /**   parent   **/
+    /****************/
+    // if no person period observations at k, then no hazard for all events
+    if (r_ks[k] != 0){
+      for(p = 1; p <= maxLevel; p ++){
+        // if no event observations for event p, then no likelyhood contribution for that event
+        if (e_kps[k][p] != 0){
+          stat += eventCosts[p] * (e_kps[k][p] * log((double) e_kps[k][p] / (double) r_ks[k]));
+        }
+      }
+    }
+    
+    /****************/
+    /** L DAUGHTER **/
+    /****************/
+    if (r_ks_L[k] != 0){
+      for(p = 1; p <= maxLevel; p ++){
+        if (e_kps_L[k][p] != 0){
+          stat_L += eventCosts[p] * (e_kps_L[k][p] * log((double) e_kps_L[k][p] / (double) r_ks_L[k]));
+        }
+      }
+    }
+    
+    /****************/
+    /** R DAUGHTER **/
+    /****************/
+    if (r_ks_R[k] != 0){
+      for(p = 1; p <= maxLevel; p ++){
+        if (e_kps_R[k][p] != 0){
+          stat_R += eventCosts[p] * (e_kps_R[k][p] * log((double) e_kps_R[k][p] / (double) r_ks_R[k]));
+        }
+      }
+    }
+    
+  }
+  
+  /* free memory
+   * h_kps e_kps r_ks
+   */
+  dealloc_uimatrix(e_kps, K, maxLevel);
+  dealloc_uivector(r_ks, K);
+  
+  dealloc_uimatrix(e_kps_L, K, maxLevel);
+  dealloc_uivector(r_ks_L, K);
+  
+  dealloc_uimatrix(e_kps_R, K, maxLevel);
+  dealloc_uivector(r_ks_R, K);
+  
+  // printf("Stat delta for split with %i observations: %f\n", n, stat_L + stat_R - stat);
+  
+  /* determine delta, return */
+  return (stat_L + stat_R - stat);
+}
+
 
 double getCustomSplitStatisticMultivariateRegressionEight (unsigned int n,
                                                            double k_for_alpha,

--- a/src/splitCustom.c
+++ b/src/splitCustom.c
@@ -65,11 +65,6 @@ void registerCustomFunctions() {
     registerThis (&multinomialSplit, CLAS_FAM, 8);
     registerThis (&getCustomSplitStatisticMultivariateRegressionEight, REGR_FAM, 8);
     
-    registerThis (&giniSplit, CLAS_FAM, 9);
-    registerThis (&getCustomSplitStatisticMultivariateRegressionNine, REGR_FAM, 9);
-    
-    registerThis (&multinomialWeightedSplit, CLAS_FAM, 10);
-    registerThis (&getCustomSplitStatisticMultivariateRegressionTen ,REGR_FAM, 10);
   //  registerThis (&getCustomSplitStatisticSurvivalTwo, SURV_FAM, 2);
   //  registerThis (&getCustomSplitStatisticCompetingRiskTwo, CRSK_FAM, 2);
 
@@ -1721,7 +1716,7 @@ double getCustomSplitStatisticMultivariateRegressionSeven (unsigned int n,
 /******************************************************************************/
 
 /**
- * Multinomial split: random survival forest with P - 1 competing risks and equal
+ * Multinomial split: random survival forest with maxLevel - 1 competing risks and equal
  * length discrete time periods
  * ------------------------------------------------------------------------
  * for speed, we unroll computations for each of the daughter nodes.
@@ -1745,13 +1740,12 @@ double multinomialSplit (unsigned int n,
                       unsigned int featureCount)
 {
   /* necessary vars */
-  // i is observation, k is strata (period), p is event, K is last period in parent leaf
+  // i is observation, p is event, k is strata (period), K is last period in parent leaf
   int i, p, k, K = 0; 
   double stat = 0.0, stat_L = 0.0, stat_R = 0.0;
   
   /**
-   * determine K; also, check that response conforms
-   * with expectations (2 classes, 1.0 and 2.0)
+   * determine K;
    */
   for (i = 1; i <= n; i++) {
     if (feature[1][i] > K){
@@ -1763,9 +1757,9 @@ double multinomialSplit (unsigned int n,
   /* arrays for results; pre-allocate everything, 
    for L and R, too, for speed */
   
-  // event set cardinalities at time tim k for revent p at parent s
+  // event set cardinalities at time k for event p in parent s
   unsigned int   **e_kps,  **e_kps_L, **e_kps_R;
-  // event set cardinalities at time tim k at parent s
+  // risk set cardinalities at time  k in parent s
   unsigned int   *r_ks, *r_ks_L, *r_ks_R;
   
   /****************/
@@ -1786,8 +1780,10 @@ double multinomialSplit (unsigned int n,
   e_kps_R = calloc_uimatrix(K, maxLevel);
   r_ks_R = calloc_uivector(K);
   
-  /* compute e_kps, r_ks and h_kps! */
+  /* compute e_kps and  r_ks! */
   /* make the pass through, count necessary quantities */
+  
+  // current resopnse, current strata
   int cur_y, cur_k;
   
   for (i = 1; i <= n; i++) {
@@ -1829,7 +1825,7 @@ double multinomialSplit (unsigned int n,
   }
   
   /* calculate the split statistic for each case; ignore
-   cases when the value of r_ks or h_kps is 0 (else will result in 
+   cases when the value of r_ks is 0 (else will result in 
    NaNs) */
   for (k = 1; k <= K; k++) {
     /*
@@ -1842,7 +1838,7 @@ double multinomialSplit (unsigned int n,
     // if no person period observations at k, then no hazard for all events
     if (r_ks[k] != 0){
       for(p = 1; p <= maxLevel; p ++){
-        // if no event observations for event p, then no likelyhood contribution for that event
+        // if no event observations for event p, then no likelihood contribution for that event
         if (e_kps[k][p] != 0){
           stat += (e_kps[k][p] * log((double) e_kps[k][p] / (double) r_ks[k]));
         }
@@ -1885,404 +1881,11 @@ double multinomialSplit (unsigned int n,
   dealloc_uimatrix(e_kps_R, K, maxLevel);
   dealloc_uivector(r_ks_R, K);
   
-  // printf("Stat delta for split with %i observations: %f\n", n, stat_L + stat_R - stat);
-  
   /* determine delta, return */
   return (stat_L + stat_R - stat);
 }
 
 double getCustomSplitStatisticMultivariateRegressionTen (unsigned int n,
-                                                           double k_for_alpha,
-                                                           char        *membership,
-                                                           double      *time,
-                                                           double      *event,
-                                                           
-                                                           unsigned int eventTypeSize,
-                                                           unsigned int eventTimeSize,
-                                                           double      *eventTime,
-                                                           
-                                                           double      *response,
-                                                           double       mean,
-                                                           double       variance,
-                                                           unsigned int maxLevel,
-                                                           
-                                                           double     **feature,
-                                                           unsigned int featureCount)
-{
-  fprintf(stderr, "outcome must be a factor; custom regression rule not yet implemented.\n");
-  exit(1);
-  
-}
-
-/**
- * Multinomial split: random survival forest with P - 1 competing risks and equal
- * length discrete time periods
- * ------------------------------------------------------------------------
- * for speed, we unroll computations for each of the daughter nodes.
- */
-double multinomialWeightedSplit (unsigned int n,
-                         double k_for_alpha,
-                         char        *membership,
-                         double      *time,
-                         double      *event,
-                         
-                         unsigned int eventTypeSize,
-                         unsigned int eventTimeSize,
-                         double      *eventTime,
-                         
-                         double      *response,
-                         double       mean,
-                         double       variance,
-                         unsigned int maxLevel,
-                         
-                         double     **feature,
-                         unsigned int featureCount)
-{
-  /* necessary vars */
-  // i is observation, k is strata (period), p is event, K is last period in parent leaf
-  int i, p, k, K = 0; 
-  double stat = 0.0, stat_L = 0.0, stat_R = 0.0;
-  const unsigned int eventCosts[3] = {1, 30, 500};
-  
-  /**
-   * determine K; also, check that response conforms
-   * with expectations (2 classes, 1.0 and 2.0)
-   */
-  for (i = 1; i <= n; i++) {
-    if (feature[1][i] > K){
-      // feature [1][i] contains period of observation i
-      K = feature[1][i];
-    } 
-  }
-  
-  /* arrays for results; pre-allocate everything, 
-   for L and R, too, for speed */
-  
-  // event set cardinalities at time tim k for revent p at parent s
-  unsigned int   **e_kps,  **e_kps_L, **e_kps_R;
-  // event set cardinalities at time tim k at parent s
-  unsigned int   *r_ks, *r_ks_L, *r_ks_R;
-  
-  /****************/
-  /**   parent   **/
-  /****************/
-  e_kps = calloc_uimatrix(K, maxLevel);
-  r_ks = calloc_uivector(K);
-  
-  /****************/
-  /** L DAUGHTER **/
-  /****************/
-  e_kps_L = calloc_uimatrix(K, maxLevel);
-  r_ks_L = calloc_uivector(K);
-  
-  /****************/
-  /** R DAUGHTER **/
-  /****************/
-  e_kps_R = calloc_uimatrix(K, maxLevel);
-  r_ks_R = calloc_uivector(K);
-  
-  /* compute e_kps, r_ks and h_kps! */
-  /* make the pass through, count necessary quantities */
-  int cur_y, cur_k;
-  
-  for (i = 1; i <= n; i++) {
-    
-    cur_y  = (int) response[i];
-    cur_k  = (int) feature[1][i];
-    // risk time 1 due to periods of length 1
-    
-    /****************/
-    /**   parent   **/
-    /****************/
-    /* increment e_kps, r_ks appropriately  */
-    /*
-     * number of persons experiecing event cur_y at k
-     */
-    e_kps[cur_k][cur_y]++;
-    /*
-     * risk set for period k is simply the number of 
-     * person period observations at k
-     */
-    r_ks[cur_k]++;
-    
-    /****************/
-    /** L DAUGHTER **/
-    /****************/
-    if (membership[i] == LEFT) {
-      e_kps_L[cur_k][cur_y]++;
-      r_ks_L[cur_k]++;
-    }
-    
-    /****************/
-    /** R DAUGHTER **/
-    /****************/
-    else {
-      e_kps_R[cur_k][cur_y]++;
-      r_ks_R[cur_k]++;
-    }
-    
-  }
-  
-  /* calculate the split statistic for each case; ignore
-   cases when the value of r_ks or h_kps is 0 (else will result in 
-   NaNs) */
-  for (k = 1; k <= K; k++) {
-    
-    /*
-     * parent negative log likelihood per period:
-     * number of event occurences * log (empirical MLE of likelhood of event occurence)
-     */
-    /****************/
-    /**   parent   **/
-    /****************/
-    // if no person period observations at k, then no hazard for all events
-    if (r_ks[k] != 0){
-      for(p = 1; p <= maxLevel; p ++){
-        // if no event observations for event p, then no likelyhood contribution for that event
-        if (e_kps[k][p] != 0){
-          stat += eventCosts[p] * (e_kps[k][p] * log((double) e_kps[k][p] / (double) r_ks[k]));
-        }
-      }
-    }
-    
-    /****************/
-    /** L DAUGHTER **/
-    /****************/
-    if (r_ks_L[k] != 0){
-      for(p = 1; p <= maxLevel; p ++){
-        if (e_kps_L[k][p] != 0){
-          stat_L += eventCosts[p] * (e_kps_L[k][p] * log((double) e_kps_L[k][p] / (double) r_ks_L[k]));
-        }
-      }
-    }
-    
-    /****************/
-    /** R DAUGHTER **/
-    /****************/
-    if (r_ks_R[k] != 0){
-      for(p = 1; p <= maxLevel; p ++){
-        if (e_kps_R[k][p] != 0){
-          stat_R += eventCosts[p] * (e_kps_R[k][p] * log((double) e_kps_R[k][p] / (double) r_ks_R[k]));
-        }
-      }
-    }
-    
-  }
-  
-  /* free memory
-   * h_kps e_kps r_ks
-   */
-  dealloc_uimatrix(e_kps, K, maxLevel);
-  dealloc_uivector(r_ks, K);
-  
-  dealloc_uimatrix(e_kps_L, K, maxLevel);
-  dealloc_uivector(r_ks_L, K);
-  
-  dealloc_uimatrix(e_kps_R, K, maxLevel);
-  dealloc_uivector(r_ks_R, K);
-  
-  // printf("Stat delta for split with %i observations: %f\n", n, stat_L + stat_R - stat);
-  
-  /* determine delta, return */
-  return (stat_L + stat_R - stat);
-}
-
-
-double getCustomSplitStatisticMultivariateRegressionEight (unsigned int n,
-                                                           double k_for_alpha,
-                                                           char        *membership,
-                                                           double      *time,
-                                                           double      *event,
-                                                           
-                                                           unsigned int eventTypeSize,
-                                                           unsigned int eventTimeSize,
-                                                           double      *eventTime,
-                                                           
-                                                           double      *response,
-                                                           double       mean,
-                                                           double       variance,
-                                                           unsigned int maxLevel,
-                                                           
-                                                           double     **feature,
-                                                           unsigned int featureCount)
-{
-  fprintf(stderr, "outcome must be a factor; custom regression rule not yet implemented.\n");
-  exit(1);
-  
-}
-
-/**
- * Gini split: random survival forest with P - 1 competing risks and equal
- * length discrete time periods
- * ------------------------------------------------------------------------
- * for speed, we unroll computations for each of the daughter nodes.
- */
-double giniSplit (unsigned int n,
-                         double k_for_alpha,
-                         char        *membership,
-                         double      *time,
-                         double      *event,
-                         
-                         unsigned int eventTypeSize,
-                         unsigned int eventTimeSize,
-                         double      *eventTime,
-                         
-                         double      *response,
-                         double       mean,
-                         double       variance,
-                         unsigned int maxLevel,
-                         
-                         double     **feature,
-                         unsigned int featureCount)
-{
-  /* necessary vars */
-  // i is observation, k is strata (period), p is event, K is last period in parent leaf
-  int i, p, k, K = 0; 
-  double stat = 0.0, stat_L = 0.0, stat_R = 0.0;
-  
-  /**
-   * determine K; also, check that response conforms
-   * with expectations (2 classes, 1.0 and 2.0)
-   */
-  for (i = 1; i <= n; i++) {
-    if (feature[1][i] > K){
-      // feature [1][i] contains period of observation i
-      K = feature[1][i];
-    } 
-  }
-  
-  /* arrays for results; pre-allocate everything, 
-   for L and R, too, for speed */
-  
-  // event set cardinalities at time tim k for revent p at parent s
-  unsigned int   **e_kps,  **e_kps_L, **e_kps_R;
-  // event set cardinalities at time tim k at parent s
-  unsigned int   *r_ks, *r_ks_L, *r_ks_R;
-  
-  /****************/
-  /**   parent   **/
-  /****************/
-  e_kps = calloc_uimatrix(K, maxLevel);
-  r_ks = calloc_uivector(K);
-  
-  /****************/
-  /** L DAUGHTER **/
-  /****************/
-  e_kps_L = calloc_uimatrix(K, maxLevel);
-  r_ks_L = calloc_uivector(K);
-  
-  /****************/
-  /** R DAUGHTER **/
-  /****************/
-  e_kps_R = calloc_uimatrix(K, maxLevel);
-  r_ks_R = calloc_uivector(K);
-  
-  /* compute e_kps, r_ks and h_kps! */
-  /* make the pass through, count necessary quantities */
-  int cur_y, cur_k;
-  
-  for (i = 1; i <= n; i++) {
-    
-    cur_y  = (int) response[i];
-    cur_k  = (int) feature[1][i];
-    // risk time 1 due to periods of length 1
-    
-    /****************/
-    /**   parent   **/
-    /****************/
-    /* increment e_kps, r_ks appropriately  */
-    /*
-     * number of persons experiecing event cur_y at k
-     */
-    e_kps[cur_k][cur_y]++;
-    /*
-     * risk set for period k is simply the number of 
-     * person period observations at k
-     */
-    r_ks[cur_k]++;
-    
-    /****************/
-    /** L DAUGHTER **/
-    /****************/
-    if (membership[i] == LEFT) {
-      e_kps_L[cur_k][cur_y]++;
-      r_ks_L[cur_k]++;
-    }
-    
-    /****************/
-    /** R DAUGHTER **/
-    /****************/
-    else {
-      e_kps_R[cur_k][cur_y]++;
-      r_ks_R[cur_k]++;
-    }
-    
-  }
-  
-  /* calculate the split statistic for each case; ignore
-   cases when the value of r_ks or h_kps is 0 (else will result in 
-   NaNs) */
-  for (k = 1; k <= K; k++) {
-    /*
-     * parent negative log likelihood per period:
-     * number of event occurences * log (empirical MLE of likelhood of event occurence)
-     */
-    /****************/
-    /**   parent   **/
-    /****************/
-    // if no person period observations at k, then no hazard for all events
-    if (r_ks[k] != 0){
-      for(p = 1; p <= maxLevel; p ++){
-        // if no event observations for event p, then no likelyhood contribution for that event
-        if (e_kps[k][p] != 0){
-          stat += ((double) e_kps[k][p] / (double) r_ks[k]) * (1 - (double) e_kps[k][p] / (double) r_ks[k]);
-        }
-      }
-    }
-    
-    /****************/
-    /** L DAUGHTER **/
-    /****************/
-    if (r_ks_L[k] != 0){
-      for(p = 1; p <= maxLevel; p ++){
-        if (e_kps_L[k][p] != 0){
-          stat_L += ((double) e_kps_L[k][p] / (double) r_ks_L[k]) * (1 - (double) e_kps_L[k][p] / (double) r_ks_L[k]);
-        }
-      }
-    }
-    
-    /****************/
-    /** R DAUGHTER **/
-    /****************/
-    if (r_ks_R[k] != 0){
-      for(p = 1; p <= maxLevel; p ++){
-        if (e_kps_R[k][p] != 0){
-          stat_R += ((double) e_kps_R[k][p] / (double) r_ks_R[k]) * (1 - (double) e_kps_R[k][p] / (double) r_ks_R[k]);
-        }
-      }
-    }
-    
-  }
-  
-  /* free memory
-   * h_kps e_kps r_ks
-   */
-  dealloc_uimatrix(e_kps, K, maxLevel);
-  dealloc_uivector(r_ks, K);
-  
-  dealloc_uimatrix(e_kps_L, K, maxLevel);
-  dealloc_uivector(r_ks_L, K);
-  
-  dealloc_uimatrix(e_kps_R, K, maxLevel);
-  dealloc_uivector(r_ks_R, K);
-  
-  // printf("Stat delta for split with %i observations: %f\n", n, stat_L + stat_R - stat);
-  
-  /* determine delta, return */
-  return (stat_L + stat_R - stat);
-}
-
-double getCustomSplitStatisticMultivariateRegressionNine (unsigned int n,
                                                            double k_for_alpha,
                                                            char        *membership,
                                                            double      *time,

--- a/src/splitCustom.c
+++ b/src/splitCustom.c
@@ -61,6 +61,9 @@ void registerCustomFunctions() {
 
     registerThis (&poissonSplit6, CLAS_FAM, 7);
     registerThis (&getCustomSplitStatisticMultivariateRegressionSeven, REGR_FAM, 7);
+    
+    registerThis (&binomialSplit, CLAS_FAM, 8);
+    registerThis (&getCustomSplitStatisticMultivariateRegressionEight, REGR_FAM, 8);
   //  registerThis (&getCustomSplitStatisticSurvivalTwo, SURV_FAM, 2);
   //  registerThis (&getCustomSplitStatisticCompetingRiskTwo, CRSK_FAM, 2);
 
@@ -1707,6 +1710,58 @@ double getCustomSplitStatisticMultivariateRegressionSeven (unsigned int n,
   fprintf(stderr, "outcome must be a factor; custom regression rule not yet implemented.\n");
   exit(1);
 
+}
+
+/******************************************************************************/
+
+/**
+ * Poisson split 6: with stratification by interval time but not risk time,
+ *                  no Bayes estimate.
+ * ------------------------------------------------------------------------
+ * for speed, we unroll computations for each of the daughter nodes.
+ */
+double binomialSplit (unsigned int n,
+                      double k_for_alpha,
+                      char        *membership,
+                      double      *time,
+                      double      *event,
+                      
+                      unsigned int eventTypeSize,
+                      unsigned int eventTimeSize,
+                      double      *eventTime,
+                      
+                      double      *response,
+                      double       mean,
+                      double       variance,
+                      unsigned int maxLevel,
+                      
+                      double     **feature,
+                      unsigned int featureCount)
+{
+  return 0;
+}
+
+double getCustomSplitStatisticMultivariateRegressionEight (unsigned int n,
+                                                           double k_for_alpha,
+                                                           char        *membership,
+                                                           double      *time,
+                                                           double      *event,
+                                                           
+                                                           unsigned int eventTypeSize,
+                                                           unsigned int eventTimeSize,
+                                                           double      *eventTime,
+                                                           
+                                                           double      *response,
+                                                           double       mean,
+                                                           double       variance,
+                                                           unsigned int maxLevel,
+                                                           
+                                                           double     **feature,
+                                                           unsigned int featureCount)
+{
+  fprintf(stderr, "outcome must be a factor; custom regression rule not yet implemented.\n");
+  exit(1);
+  
 }
 
 /*

--- a/src/splitCustom.c
+++ b/src/splitCustom.c
@@ -1768,20 +1768,20 @@ double multinomialSplit (unsigned int n,
   /****************/
   /**   parent   **/
   /****************/
-  e_kps = alloc_uimatrix(K, maxLevel);
-  r_ks = alloc_uivector(K);
+  e_kps = calloc_uimatrix(K, maxLevel);
+  r_ks = calloc_uivector(K);
   
   /****************/
   /** L DAUGHTER **/
   /****************/
-  e_kps_L = alloc_uimatrix(K, maxLevel);
-  r_ks_L = alloc_uivector(K);
+  e_kps_L = calloc_uimatrix(K, maxLevel);
+  r_ks_L = calloc_uivector(K);
   
   /****************/
   /** R DAUGHTER **/
   /****************/
-  e_kps_R = alloc_uimatrix(K, maxLevel);
-  r_ks_R = alloc_uivector(K);
+  e_kps_R = calloc_uimatrix(K, maxLevel);
+  r_ks_R = calloc_uivector(K);
   
   /* compute e_kps, r_ks and h_kps! */
   /* make the pass through, count necessary quantities */
@@ -1962,20 +1962,20 @@ double giniSplit (unsigned int n,
   /****************/
   /**   parent   **/
   /****************/
-  e_kps = alloc_uimatrix(K, maxLevel);
-  r_ks = alloc_uivector(K);
+  e_kps = calloc_uimatrix(K, maxLevel);
+  r_ks = calloc_uivector(K);
   
   /****************/
   /** L DAUGHTER **/
   /****************/
-  e_kps_L = alloc_uimatrix(K, maxLevel);
-  r_ks_L = alloc_uivector(K);
+  e_kps_L = calloc_uimatrix(K, maxLevel);
+  r_ks_L = calloc_uivector(K);
   
   /****************/
   /** R DAUGHTER **/
   /****************/
-  e_kps_R = alloc_uimatrix(K, maxLevel);
-  r_ks_R = alloc_uivector(K);
+  e_kps_R = calloc_uimatrix(K, maxLevel);
+  r_ks_R = calloc_uivector(K);
   
   /* compute e_kps, r_ks and h_kps! */
   /* make the pass through, count necessary quantities */
@@ -2122,6 +2122,11 @@ unsigned int *alloc_uivector(unsigned int nh)
   return (unsigned int *) malloc((size_t) ((nh+1) * (sizeof(unsigned int))));
 }
 
+unsigned int *calloc_uivector(unsigned int nh)
+{
+  return (unsigned int* ) calloc(nh + 1, sizeof(unsigned int));
+}
+
 void dealloc_uivector(unsigned int *v, unsigned int nh)
 {
   free((char *) v);
@@ -2144,6 +2149,16 @@ unsigned int **alloc_uimatrix(unsigned int n2h, unsigned int nh)
 
   for (unsigned int i = 1; i <= n2h; i++) {
     v[i] = alloc_uivector(nh);
+  }
+  return v;
+}
+
+unsigned int **calloc_uimatrix(unsigned int n2h, unsigned int nh)
+{
+  unsigned int **v = (unsigned int **) calloc(n2h + 1, sizeof(unsigned int *));
+  
+  for (unsigned int i = 1; i <= n2h; i++) {
+    v[i] = calloc_uivector(nh);
   }
   return v;
 }

--- a/src/splitCustom.c
+++ b/src/splitCustom.c
@@ -1885,7 +1885,7 @@ double multinomialSplit (unsigned int n,
   return (stat_L + stat_R - stat);
 }
 
-double getCustomSplitStatisticMultivariateRegressionTen (unsigned int n,
+double getCustomSplitStatisticMultivariateRegressionEight (unsigned int n,
                                                            double k_for_alpha,
                                                            char        *membership,
                                                            double      *time,

--- a/src/splitCustom.c
+++ b/src/splitCustom.c
@@ -1760,34 +1760,28 @@ double multinomialSplit (unsigned int n,
   /* arrays for results; pre-allocate everything, 
    for L and R, too, for speed */
   
+  // event set cardinalities at time tim k for revent p at parent s
+  unsigned int   **e_kps,  **e_kps_L, **e_kps_R;
+  // event set cardinalities at time tim k at parent s
+  unsigned int   *r_ks, *r_ks_L, *r_ks_R;
+  
   /****************/
   /**   parent   **/
   /****************/
-  // occurence of event p at time k in parent s
-  int** e_kps = calloc((K + 1), sizeof(int*));
-  for (i = 0; i < K + 1; i++) {
-    e_kps[i] = calloc((maxLevel + 1), sizeof(int));
-  }
-  // risk set at time k in parent s
-  int *r_ks  = calloc((K + 1), sizeof(int));
+  e_kps = alloc_uimatrix(K, maxLevel);
+  r_ks = alloc_uivector(K);
   
   /****************/
   /** L DAUGHTER **/
   /****************/
-  int** e_kps_L = calloc((K + 1), sizeof(int*));
-  for (i = 0; i < K + 1; i++) {
-    e_kps_L[i] = calloc((maxLevel + 1), sizeof(int));
-  }
-  int *r_ks_L  = calloc((K + 1), sizeof(int));
+  e_kps_L = alloc_uimatrix(K, maxLevel);
+  r_ks_L = alloc_uivector(K);
   
   /****************/
   /** R DAUGHTER **/
   /****************/
-  int** e_kps_R = calloc((K + 1), sizeof(int*));
-  for (i = 0; i < K + 1; i++) {
-    e_kps_R[i] = calloc((maxLevel + 1), sizeof(int));
-  }
-  int *r_ks_R  = calloc((K + 1), sizeof(int));
+  e_kps_R = alloc_uimatrix(K, maxLevel);
+  r_ks_R = alloc_uivector(K);
   
   /* compute e_kps, r_ks and h_kps! */
   /* make the pass through, count necessary quantities */
@@ -1879,12 +1873,14 @@ double multinomialSplit (unsigned int n,
   /* free memory
    * h_kps e_kps r_ks
    */
-  free(e_kps);
-  free(r_ks);
-  free(e_kps_L);
-  free(r_ks_L);
-  free(e_kps_R);
-  free(r_ks_R);
+  dealloc_uimatrix(e_kps, K, maxLevel);
+  dealloc_uivector(r_ks, K);
+  
+  dealloc_uimatrix(e_kps_L, K, maxLevel);
+  dealloc_uivector(r_ks_L, K);
+  
+  dealloc_uimatrix(e_kps_R, K, maxLevel);
+  dealloc_uivector(r_ks_R, K);
   
   // printf("Stat delta for split with %i observations: %f\n", n, stat_L + stat_R - stat);
   
@@ -1958,34 +1954,28 @@ double giniSplit (unsigned int n,
   /* arrays for results; pre-allocate everything, 
    for L and R, too, for speed */
   
+  // event set cardinalities at time tim k for revent p at parent s
+  unsigned int   **e_kps,  **e_kps_L, **e_kps_R;
+  // event set cardinalities at time tim k at parent s
+  unsigned int   *r_ks, *r_ks_L, *r_ks_R;
+  
   /****************/
   /**   parent   **/
   /****************/
-  // occurence of event p at time k in parent s
-  int** e_kps = calloc((K + 1), sizeof(int*));
-  for (i = 0; i < K + 1; i++) {
-    e_kps[i] = calloc((maxLevel + 1), sizeof(int));
-  }
-  // risk set at time k in parent s
-  int *r_ks  = calloc((K + 1), sizeof(int));
+  e_kps = alloc_uimatrix(K, maxLevel);
+  r_ks = alloc_uivector(K);
   
   /****************/
   /** L DAUGHTER **/
   /****************/
-  int** e_kps_L = calloc((K + 1), sizeof(int*));
-  for (i = 0; i < K + 1; i++) {
-    e_kps_L[i] = calloc((maxLevel + 1), sizeof(int));
-  }
-  int *r_ks_L  = calloc((K + 1), sizeof(int));
+  e_kps_L = alloc_uimatrix(K, maxLevel);
+  r_ks_L = alloc_uivector(K);
   
   /****************/
   /** R DAUGHTER **/
   /****************/
-  int** e_kps_R = calloc((K + 1), sizeof(int*));
-  for (i = 0; i < K + 1; i++) {
-    e_kps_R[i] = calloc((maxLevel + 1), sizeof(int));
-  }
-  int *r_ks_R  = calloc((K + 1), sizeof(int));
+  e_kps_R = alloc_uimatrix(K, maxLevel);
+  r_ks_R = alloc_uivector(K);
   
   /* compute e_kps, r_ks and h_kps! */
   /* make the pass through, count necessary quantities */
@@ -2077,12 +2067,14 @@ double giniSplit (unsigned int n,
   /* free memory
    * h_kps e_kps r_ks
    */
-  free(e_kps);
-  free(r_ks);
-  free(e_kps_L);
-  free(r_ks_L);
-  free(e_kps_R);
-  free(r_ks_R);
+  dealloc_uimatrix(e_kps, K, maxLevel);
+  dealloc_uivector(r_ks, K);
+  
+  dealloc_uimatrix(e_kps_L, K, maxLevel);
+  dealloc_uivector(r_ks_L, K);
+  
+  dealloc_uimatrix(e_kps_R, K, maxLevel);
+  dealloc_uivector(r_ks_R, K);
   
   // printf("Stat delta for split with %i observations: %f\n", n, stat_L + stat_R - stat);
   

--- a/src/splitCustom.h
+++ b/src/splitCustom.h
@@ -256,42 +256,6 @@ double getCustomSplitStatisticMultivariateRegressionEight (unsigned int n,
                                                            double     **feature,
                                                            unsigned int featureCount);
 
-double getCustomSplitStatisticMultivariateRegressionNine (unsigned int n,
-                                                           double k_for_alpha,
-                                                           char        *membership,
-                                                           double      *time,
-                                                           double      *event,
-                                                           
-                                                           unsigned int eventTypeSize,
-                                                           unsigned int eventTimeSize,
-                                                           double      *eventTime,
-                                                           
-                                                           double      *response,
-                                                           double       mean,
-                                                           double       variance,
-                                                           unsigned int maxLevel,
-                                                           
-                                                           double     **feature,
-                                                           unsigned int featureCount);
-
-double getCustomSplitStatisticMultivariateRegressionTen (unsigned int n,
-                                                          double k_for_alpha,
-                                                          char        *membership,
-                                                          double      *time,
-                                                          double      *event,
-                                                          
-                                                          unsigned int eventTypeSize,
-                                                          unsigned int eventTimeSize,
-                                                          double      *eventTime,
-                                                          
-                                                          double      *response,
-                                                          double       mean,
-                                                          double       variance,
-                                                          unsigned int maxLevel,
-                                                          
-                                                          double     **feature,
-                                                          unsigned int featureCount);
-
 /* bayesian estimate splits */
 double poissonSplit1 (unsigned int n,
                       double k_for_alpha,
@@ -419,42 +383,6 @@ double multinomialSplit (unsigned int n,
                       
                       double     **feature,
                       unsigned int featureCount);
-
-double giniSplit (unsigned int n,
-                  double k_for_alpha,
-                  char        *membership,
-                  double      *time,
-                  double      *event,
-                  
-                  unsigned int eventTypeSize,
-                  unsigned int eventTimeSize,
-                  double      *eventTime,
-                  
-                  double      *response,
-                  double       mean,
-                  double       variance,
-                  unsigned int maxLevel,
-                  
-                  double     **feature,
-                  unsigned int featureCount);
-
-double multinomialWeightedSplit (unsigned int n,
-                         double k_for_alpha,
-                         char        *membership,
-                         double      *time,
-                         double      *event,
-                         
-                         unsigned int eventTypeSize,
-                         unsigned int eventTimeSize,
-                         double      *eventTime,
-                         
-                         double      *response,
-                         double       mean,
-                         double       variance,
-                         unsigned int maxLevel,
-                         
-                         double     **feature,
-                         unsigned int featureCount);
 
 unsigned int *alloc_uivector(unsigned int nh);
 void          dealloc_uivector(unsigned int *v, unsigned int nh);

--- a/src/splitCustom.h
+++ b/src/splitCustom.h
@@ -274,6 +274,24 @@ double getCustomSplitStatisticMultivariateRegressionNine (unsigned int n,
                                                            double     **feature,
                                                            unsigned int featureCount);
 
+double getCustomSplitStatisticMultivariateRegressionTen (unsigned int n,
+                                                          double k_for_alpha,
+                                                          char        *membership,
+                                                          double      *time,
+                                                          double      *event,
+                                                          
+                                                          unsigned int eventTypeSize,
+                                                          unsigned int eventTimeSize,
+                                                          double      *eventTime,
+                                                          
+                                                          double      *response,
+                                                          double       mean,
+                                                          double       variance,
+                                                          unsigned int maxLevel,
+                                                          
+                                                          double     **feature,
+                                                          unsigned int featureCount);
+
 /* bayesian estimate splits */
 double poissonSplit1 (unsigned int n,
                       double k_for_alpha,
@@ -419,6 +437,24 @@ double giniSplit (unsigned int n,
                   
                   double     **feature,
                   unsigned int featureCount);
+
+double multinomialWeightedSplit (unsigned int n,
+                         double k_for_alpha,
+                         char        *membership,
+                         double      *time,
+                         double      *event,
+                         
+                         unsigned int eventTypeSize,
+                         unsigned int eventTimeSize,
+                         double      *eventTime,
+                         
+                         double      *response,
+                         double       mean,
+                         double       variance,
+                         unsigned int maxLevel,
+                         
+                         double     **feature,
+                         unsigned int featureCount);
 
 unsigned int *alloc_uivector(unsigned int nh);
 void          dealloc_uivector(unsigned int *v, unsigned int nh);

--- a/src/splitCustom.h
+++ b/src/splitCustom.h
@@ -428,3 +428,7 @@ void          dealloc_dvector(double *v, unsigned int nh);
 
 unsigned int **alloc_uimatrix(unsigned int n2h, unsigned int nh);
 void          dealloc_uimatrix(unsigned int **v, unsigned int n2h, unsigned int nh);
+
+unsigned int *calloc_uivector(unsigned int nh);
+unsigned int **calloc_uimatrix(unsigned int n2h, unsigned int nh);
+   

--- a/src/splitCustom.h
+++ b/src/splitCustom.h
@@ -366,7 +366,7 @@ double poissonSplit6 (unsigned int n,
                       double     **feature,
                       unsigned int featureCount);
 
-double binomialSplit (unsigned int n,
+double multinomialSplit (unsigned int n,
                       double k_for_alpha,
                       char        *membership,
                       double      *time,

--- a/src/splitCustom.h
+++ b/src/splitCustom.h
@@ -238,6 +238,24 @@ double getCustomSplitStatisticMultivariateRegressionSeven (unsigned int n,
                                                       double     **feature,
                                                       unsigned int featureCount);
 
+double getCustomSplitStatisticMultivariateRegressionEight (unsigned int n,
+                                                           double k_for_alpha,
+                                                           char        *membership,
+                                                           double      *time,
+                                                           double      *event,
+                                                           
+                                                           unsigned int eventTypeSize,
+                                                           unsigned int eventTimeSize,
+                                                           double      *eventTime,
+                                                           
+                                                           double      *response,
+                                                           double       mean,
+                                                           double       variance,
+                                                           unsigned int maxLevel,
+                                                           
+                                                           double     **feature,
+                                                           unsigned int featureCount);
+
 /* bayesian estimate splits */
 double poissonSplit1 (unsigned int n,
                       double k_for_alpha,
@@ -340,6 +358,24 @@ double poissonSplit6 (unsigned int n,
                       unsigned int eventTimeSize,
                       double      *eventTime,
 
+                      double      *response,
+                      double       mean,
+                      double       variance,
+                      unsigned int maxLevel,
+                      
+                      double     **feature,
+                      unsigned int featureCount);
+
+double binomialSplit (unsigned int n,
+                      double k_for_alpha,
+                      char        *membership,
+                      double      *time,
+                      double      *event,
+                      
+                      unsigned int eventTypeSize,
+                      unsigned int eventTimeSize,
+                      double      *eventTime,
+                      
                       double      *response,
                       double       mean,
                       double       variance,

--- a/src/splitCustom.h
+++ b/src/splitCustom.h
@@ -256,6 +256,24 @@ double getCustomSplitStatisticMultivariateRegressionEight (unsigned int n,
                                                            double     **feature,
                                                            unsigned int featureCount);
 
+double getCustomSplitStatisticMultivariateRegressionNine (unsigned int n,
+                                                           double k_for_alpha,
+                                                           char        *membership,
+                                                           double      *time,
+                                                           double      *event,
+                                                           
+                                                           unsigned int eventTypeSize,
+                                                           unsigned int eventTimeSize,
+                                                           double      *eventTime,
+                                                           
+                                                           double      *response,
+                                                           double       mean,
+                                                           double       variance,
+                                                           unsigned int maxLevel,
+                                                           
+                                                           double     **feature,
+                                                           unsigned int featureCount);
+
 /* bayesian estimate splits */
 double poissonSplit1 (unsigned int n,
                       double k_for_alpha,
@@ -383,6 +401,24 @@ double multinomialSplit (unsigned int n,
                       
                       double     **feature,
                       unsigned int featureCount);
+
+double giniSplit (unsigned int n,
+                  double k_for_alpha,
+                  char        *membership,
+                  double      *time,
+                  double      *event,
+                  
+                  unsigned int eventTypeSize,
+                  unsigned int eventTimeSize,
+                  double      *eventTime,
+                  
+                  double      *response,
+                  double       mean,
+                  double       variance,
+                  unsigned int maxLevel,
+                  
+                  double     **feature,
+                  unsigned int featureCount);
 
 unsigned int *alloc_uivector(unsigned int nh);
 void          dealloc_uivector(unsigned int *v, unsigned int nh);


### PR DESCRIPTION
I added a multivariate log-likelihood splitting rule that is suitable for competing risk settings (i.e. a number of mutually exclusive and non-recurring events). This rule is similar to that proposed in the paper by Bou-Hamad but extended to a competing risks and now embedded in your rfSLAM framework. 

Imad Bou-hamad, Denis Larocque, Hatem Ben-Ameur, Louise C. Masse, Frank Vitaro, and Richard E. Tremblay. Discrete-time survival trees. Canadian Journal of Statistics, 37(1):17–32, March 2009.

https://journals.sagepub.com/doi/10.1177/1471082X1001100503